### PR TITLE
Fix compiler errors

### DIFF
--- a/c/meterpreter/source/common/common_metapi.h
+++ b/c/meterpreter/source/common/common_metapi.h
@@ -159,11 +159,6 @@ typedef struct _ListApi
 	VOID(*destroy)(PLIST pList);
 } ListApi;
 
-typedef struct v6netmask
-{
-	unsigned mask[4];
-} v6netmask;
-
 #ifdef DEBUGTRACE
 typedef struct _LoggingApi
 {

--- a/c/meterpreter/source/extensions/stdapi/server/net/config/route.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/config/route.c
@@ -1,10 +1,17 @@
 #include "precomp.h"
+#include "common.h"
 #include "common_metapi.h"
+#include <netioapi.h>
+
+typedef struct v6netmask
+{
+	unsigned int mask[4];
+} v6netmask;
 
 DWORD add_remove_route(Packet *request, BOOLEAN add);
 
-int bit32mask(unsigned bits){
-    unsigned netmask;
+static unsigned int bit32mask(unsigned bits){
+    unsigned int netmask;
     if (bits == 32)
         netmask = 0xffffffff;
     else{
@@ -13,9 +20,8 @@ int bit32mask(unsigned bits){
     return netmask;
 }
 
-void bit128mask(unsigned bits, v6netmask* netmask){
-    unsigned part;
-    part = bit32mask(bits);
+static void bit128mask(unsigned int bits, v6netmask* netmask){
+    unsigned int part = bit32mask(bits);
     if (bits >= 96){
         netmask->mask[0] = 0xffffffff;
         netmask->mask[1] = 0xffffffff;
@@ -48,125 +54,117 @@ void bit128mask(unsigned bits, v6netmask* netmask){
 DWORD request_net_config_get_routes(Remote *remote, Packet *packet)
 {
 	Packet *response = met_api->packet.create_response(packet);
-	DWORD result = ERROR_SUCCESS;
+	DWORD dwResult = ERROR_SUCCESS;
 	DWORD index;
 	DWORD metric_bigendian;
 
 	PMIB_IPFORWARDTABLE table_ipv4 = NULL;
-	PMIB_IPFORWARD_TABLE2 val = NULL;
-	PMIB_IPFORWARD_TABLE2 *table_ipv6 = &val;
+	PMIB_IPFORWARD_TABLE2 table_ipv6 = NULL;
 	DWORD tableSize = sizeof(MIB_IPFORWARDROW) * 96;
 	char int_name[20];
 
 	do
 	{
-//		 Allocate storage for the routing table
+		//		 Allocate storage for the routing table
 		if (!(table_ipv4 = (PMIB_IPFORWARDTABLE)malloc(tableSize)))
 		{
-			result = ERROR_NOT_ENOUGH_MEMORY;
+			dwResult = ERROR_NOT_ENOUGH_MEMORY;
 			break;
 		}
 
-//		 Get the routing table
+		//		 Get the routing table
 		if (GetIpForwardTable(table_ipv4, &tableSize, TRUE) != NO_ERROR)
 		{
-			result = GetLastError();
-			break;
+			BREAK_ON_ERROR("[NET] request_net_config_get_routes: GetIpForwardTable failed");
 		}
 
 		// Enumerate it
 		for (index = 0;
-		     index < table_ipv4->dwNumEntries;
-		     index++)
+			index < table_ipv4->dwNumEntries;
+			index++)
 		{
 			Tlv route[5];
-			memset(int_name, 0, 20);
+			memset(int_name, 0, sizeof(int_name));
 
-			route[0].header.type   = TLV_TYPE_SUBNET;
+			route[0].header.type = TLV_TYPE_SUBNET;
 			route[0].header.length = sizeof(DWORD);
-			route[0].buffer        = (PUCHAR)&table_ipv4->table[index].dwForwardDest;
-			route[1].header.type   = TLV_TYPE_NETMASK;
+			route[0].buffer = (PUCHAR)&table_ipv4->table[index].dwForwardDest;
+			route[1].header.type = TLV_TYPE_NETMASK;
 			route[1].header.length = sizeof(DWORD);
-			route[1].buffer        = (PUCHAR)&table_ipv4->table[index].dwForwardMask;
-			route[2].header.type   = TLV_TYPE_GATEWAY;
+			route[1].buffer = (PUCHAR)&table_ipv4->table[index].dwForwardMask;
+			route[2].header.type = TLV_TYPE_GATEWAY;
 			route[2].header.length = sizeof(DWORD);
-			route[2].buffer        = (PUCHAR)&table_ipv4->table[index].dwForwardNextHop;
+			route[2].buffer = (PUCHAR)&table_ipv4->table[index].dwForwardNextHop;
 
 			// we just get the interface index, not the name, because names can be __long__
-            _itoa(table_ipv4->table[index].dwForwardIfIndex, int_name, 10);
-    		route[3].header.type   = TLV_TYPE_STRING;
+			_itoa(table_ipv4->table[index].dwForwardIfIndex, int_name, 10);
+			route[3].header.type = TLV_TYPE_STRING;
+			route[3].header.length = (DWORD)strlen(int_name) + 1;
+			route[3].buffer = (PUCHAR)int_name;
+
+			metric_bigendian = htonl(table_ipv4->table[index].dwForwardMetric1);
+			route[4].header.type = TLV_TYPE_ROUTE_METRIC;
+			route[4].header.length = sizeof(DWORD);
+			route[4].buffer = (PUCHAR)&metric_bigendian;
+
+			met_api->packet.add_tlv_group(response, TLV_TYPE_NETWORK_ROUTE,
+				route, 5);
+		}
+
+		if (GetIpForwardTable2(AF_INET6, &table_ipv6) != NO_ERROR) {
+			BREAK_ON_ERROR("[NET] request_net_config_get_routes: GetIpForwardTable2 failed");
+		}
+
+		v6netmask v6_mask;
+		MIB_IPINTERFACE_ROW iface = { .Family = AF_INET6 };
+		// Enumerate it
+		for (index = 0;
+				index < table_ipv6->NumEntries;
+				index++)
+		{
+			Tlv route[5];
+			memset(int_name, 0, sizeof(int_name));
+			iface.InterfaceIndex = table_ipv6->Table[index].InterfaceIndex;
+			if (GetIpInterfaceEntry(&iface) != NO_ERROR)
+			{
+				CONTINUE_ON_ERROR("[NET] request_net_config_get_routes: GetIpInterfaceEntry failed");
+			}
+
+			route[0].header.type   = TLV_TYPE_SUBNET;
+			route[0].header.length = sizeof(DWORD)*4;
+			route[0].buffer        = (PUCHAR)&table_ipv6->Table[index].DestinationPrefix.Prefix.Ipv6.sin6_addr;
+
+			bit128mask(table_ipv6->Table[index].DestinationPrefix.PrefixLength, &v6_mask);
+			route[1].header.type   = TLV_TYPE_NETMASK;
+			route[1].header.length = sizeof(DWORD)*4;
+			route[1].buffer        = (PUCHAR)v6_mask.mask;
+
+			route[2].header.type   = TLV_TYPE_GATEWAY;
+			route[2].header.length = sizeof(DWORD)*4;
+			route[2].buffer        = (PUCHAR)&table_ipv6->Table[index].NextHop.Ipv6.sin6_addr;
+
+			// we just get the interface index, not the name, because names can be __long__
+			_itoa(table_ipv6->Table[index].InterfaceIndex, int_name, 10);
+			route[3].header.type   = TLV_TYPE_STRING;
 			route[3].header.length = (DWORD)strlen(int_name)+1;
 			route[3].buffer        = (PUCHAR)int_name;
 
-			metric_bigendian = htonl(table_ipv4->table[index].dwForwardMetric1);
+			metric_bigendian = htonl(table_ipv6->Table[index].Metric + iface.Metric);
 			route[4].header.type   = TLV_TYPE_ROUTE_METRIC;
-			route[4].header.length = sizeof(DWORD);	
+			route[4].header.length = sizeof(DWORD);
 			route[4].buffer        = (PUCHAR)&metric_bigendian;
 
 			met_api->packet.add_tlv_group(response, TLV_TYPE_NETWORK_ROUTE,
 					route, 5);
 		}
-
-		if (GetIpForwardTable2(AF_INET6, table_ipv6) == NO_ERROR)
-        {
-			// Enumerate it
-			for (index = 0;
-					index < val->NumEntries;
-					index++)
-			{
-				Tlv route[5];
-				memset(int_name, 0, 20);
-				v6netmask* v6_mask = malloc(sizeof(v6netmask));
-				PMIB_IPINTERFACE_ROW iface = malloc(sizeof(MIB_IPINTERFACE_ROW));
-				iface->Family = AF_INET6;
-				iface->InterfaceIndex = val->Table[index].InterfaceIndex;
-				if (GetIpInterfaceEntry(iface) != NO_ERROR)
-				{
-					result = GetLastError();
-					break;
-				}	 
-
-				route[0].header.type   = TLV_TYPE_SUBNET;
-				route[0].header.length = sizeof(DWORD)*4;
-				route[0].buffer        = (PUCHAR)&val->Table[index].DestinationPrefix.Prefix.Ipv6.sin6_addr;
-				bit128mask(val->Table[index].DestinationPrefix.PrefixLength, v6_mask);
-				route[1].header.type   = TLV_TYPE_NETMASK;
-				route[1].header.length = sizeof(DWORD)*4;
-				route[1].buffer        = (PUCHAR)&v6_mask->mask;
-				route[2].header.type   = TLV_TYPE_GATEWAY;
-				route[2].header.length = sizeof(DWORD)*4;
-				route[2].buffer        = (PUCHAR)&val->Table[index].NextHop.Ipv6.sin6_addr;
-
-				// we just get the interface index, not the name, because names can be __long__
-				_itoa(val->Table[index].InterfaceIndex, int_name, 10);
-				route[3].header.type   = TLV_TYPE_STRING;
-				route[3].header.length = (DWORD)strlen(int_name)+1;
-				route[3].buffer        = (PUCHAR)int_name;
-
-				metric_bigendian = htonl(val->Table[index].Metric + iface->Metric);
-				route[4].header.type   = TLV_TYPE_ROUTE_METRIC;
-				route[4].header.length = sizeof(DWORD);
-				route[4].buffer        = (PUCHAR)&metric_bigendian;
-
-				met_api->packet.add_tlv_group(response, TLV_TYPE_NETWORK_ROUTE,
-						route, 5);
-				free(v6_mask);
-				free(iface);
-			}
-		}
-		else
-		{
-			result = GetLastError();
-			break;
-		}
 	} while (0);
 
 	if(table_ipv4)
 		free(table_ipv4);
-	if(val)
-		free(val);
+	if(table_ipv6)
+		free(table_ipv6);
 
-	met_api->packet.transmit_response(result, remote, response);
+	met_api->packet.transmit_response(dwResult, remote, response);
 
 	return ERROR_SUCCESS;
 }

--- a/c/meterpreter/source/extensions/stdapi/server/net/config/route.c
+++ b/c/meterpreter/source/extensions/stdapi/server/net/config/route.c
@@ -3,6 +3,8 @@
 #include "common_metapi.h"
 #include <netioapi.h>
 
+typedef NETIO_STATUS(NETIOAPI_API_* GETIPFORWARDTABLE2)(ADDRESS_FAMILY Family, PMIB_IPFORWARD_TABLE2* Table);
+
 typedef struct v6netmask
 {
 	unsigned int mask[4];
@@ -111,12 +113,18 @@ DWORD request_net_config_get_routes(Remote *remote, Packet *packet)
 				route, 5);
 		}
 
-		if (GetIpForwardTable2(AF_INET6, &table_ipv6) != NO_ERROR) {
+		v6netmask v6_mask;
+		MIB_IPINTERFACE_ROW iface = { .Family = AF_INET6 };
+		GETIPFORWARDTABLE2 pGetIpForwardTable2 = (GETIPFORWARDTABLE2)GetProcAddress(GetModuleHandle(TEXT("Iphlpapi.dll")), "GetIpForwardTable2");
+
+		// GetIpForwardTable2 is only available on Windows Vista and later.
+		if (!pGetIpForwardTable2) {
+			break;
+		}
+		if (pGetIpForwardTable2(AF_INET6, &table_ipv6) != NO_ERROR) {
 			BREAK_ON_ERROR("[NET] request_net_config_get_routes: GetIpForwardTable2 failed");
 		}
 
-		v6netmask v6_mask;
-		MIB_IPINTERFACE_ROW iface = { .Family = AF_INET6 };
 		// Enumerate it
 		for (index = 0;
 				index < table_ipv6->NumEntries;

--- a/c/meterpreter/source/extensions/stdapi/server/precomp.h
+++ b/c/meterpreter/source/extensions/stdapi/server/precomp.h
@@ -6,7 +6,6 @@
 #define  _WIN32_WINNT _WIN32_WINNT_WIN2K
 #include "../stdapi.h"
 #include <tlhelp32.h>
-#include <netioapi.h>
 #include <iphlpapi.h>
 #include "resource/resource.h"
 


### PR DESCRIPTION
This makes a few changes as listed below.

1. Fixes compiler errors by reverting changes to `precomp.h`
2. Moves the `v6netmask` type definition into `route.c` so it's not exposed to files that don't need it.
3. Uses `GetProcAddress` to find `GetIpForwardTable2` to fix XP compatibility. Meterpreter still support Windows XP SP 2 and later, see https://github.com/rapid7/metasploit-framework/pull/14528.
4. Switches `result` to `dwResult` and includes `common.h` for debugging macros. I needed this while I was testing some things.
5. Switches `v6_mask` and `iface` to be local variables on the stack. This fixed:
    1. A problem I was running into where `iface` wasn't initialized to zero which caused `GetIpInterfaceEntry` to fail.
    2. A memory leak where if `GetIpInterfaceEntry` failed, the values weren't freed.
    3. Should make things faster because the allocation and free operation can be skipped.
6. Switched back to using `table_ipv6` which made things more readable.